### PR TITLE
Sort files into their own respective directories by extension

### DIFF
--- a/MainShell.rb
+++ b/MainShell.rb
@@ -13,7 +13,7 @@ class MainShell
 
     body {
         shell {
-            minimum_size 1000, 1000
+            minimum_size 100, 100
             tab_folder {
                 tab_item {
                     text "Move files to junk folder"

--- a/src/TxtFilesToJunkFolder.rb
+++ b/src/TxtFilesToJunkFolder.rb
@@ -2,10 +2,13 @@ require 'fileutils'
 
 include Glimmer
 
-def toJunkFolder(extension)
-  Dir.mkdir("junk")
+def toJunkFolder(extension) 
+  if !Dir.exist?(extension)
+    directory_name = extension[1].upcase + extension[2..-1] + ' files'
+    Dir.mkdir(directory_name) 
+  end
   s = Dir["./*" + extension]
   s.each { |file|
-    FileUtils.mv(file, './junk')
+  FileUtils.mv(file, "./" + directory_name)
   }
 end


### PR DESCRIPTION
Instead of a universal 'junk' folder, sort the files into directories based on their specific extensions